### PR TITLE
Add basic pip output parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ changelog-checker -i updates.txt
 
 # or get html report
 changelog-checker -i updates.txt -f html -o report.html
+
+# or use with (uv) pip to check changelogs of pinned dependencies
+uv pip list --outdated | changelog-checker -p pip
 ```
 
 ## Usage
@@ -72,7 +75,7 @@ uv sync -U 2>&1 | changelog-checker
 ```bash
 Options:
   -i, --input-file FILENAME       Read input from file instead of stdin
-  -p, --parser [uv]               Parser type to use (default: uv)
+  -p, --parser [uv|pip]           Parser type to use (default: uv)
   --log-level [DEBUG|INFO|WARNING|ERROR]
                                   Logging level (default: INFO)
   -v, --verbose                   Enable verbose output (equivalent to --log-
@@ -169,6 +172,7 @@ changelog-checker -i updates.txt -f html -o report.html
 Currently supported:
 
 - **uv**: Python package manager
+- **pip**: Pip (only "list --outdated")
 
 ## How It Works
 

--- a/changelog_checker/cli.py
+++ b/changelog_checker/cli.py
@@ -23,7 +23,7 @@ from .utils import ChangelogCheckerError, NetworkError, ParserError, setup_loggi
     "--parser",
     "-p",
     default="uv",
-    type=click.Choice(["uv"]),
+    type=click.Choice(["uv", "pip"]),
     help="Parser type to use (default: uv)",
 )
 @click.option(

--- a/changelog_checker/core.py
+++ b/changelog_checker/core.py
@@ -6,7 +6,7 @@ import logging
 
 from .models import ChangeType, DependencyChange, PackageReport
 from .output import HTMLFormatter, RichFormatter
-from .parsers import UVParser
+from .parsers import UVParser, PipParser
 from .research import ChangelogFinder, PackageFinder
 from .utils import ChangelogCheckerError, NetworkError, ParserError
 
@@ -45,6 +45,8 @@ class ChangelogChecker:
         try:
             if parser_type == "uv":
                 parser = UVParser()
+            elif parser_type == "pip":
+                parser = PipParser()
             else:
                 raise ParserError(f"Unsupported parser type: {parser_type}")
             if not parser.validate_output(input_text):

--- a/changelog_checker/core.py
+++ b/changelog_checker/core.py
@@ -6,7 +6,7 @@ import logging
 
 from .models import ChangeType, DependencyChange, PackageReport
 from .output import HTMLFormatter, RichFormatter
-from .parsers import UVParser, PipParser
+from .parsers import BaseParser, PipParser, UVParser
 from .research import ChangelogFinder, PackageFinder
 from .utils import ChangelogCheckerError, NetworkError, ParserError
 
@@ -43,6 +43,7 @@ class ChangelogChecker:
             List of PackageReport objects
         """
         try:
+            parser: BaseParser
             if parser_type == "uv":
                 parser = UVParser()
             elif parser_type == "pip":

--- a/changelog_checker/parsers/__init__.py
+++ b/changelog_checker/parsers/__init__.py
@@ -4,5 +4,6 @@ Parsers for different package manager outputs.
 
 from .base import BaseParser
 from .uv_parser import UVParser
+from .pip_parser import PipParser
 
-__all__ = ["BaseParser", "UVParser"]
+__all__ = ["BaseParser", "UVParser", "PipParser"]

--- a/changelog_checker/parsers/__init__.py
+++ b/changelog_checker/parsers/__init__.py
@@ -3,7 +3,7 @@ Parsers for different package manager outputs.
 """
 
 from .base import BaseParser
-from .uv_parser import UVParser
 from .pip_parser import PipParser
+from .uv_parser import UVParser
 
 __all__ = ["BaseParser", "UVParser", "PipParser"]

--- a/changelog_checker/parsers/pip_parser.py
+++ b/changelog_checker/parsers/pip_parser.py
@@ -15,7 +15,7 @@ class PipParser(BaseParser):
 
     def validate_output(self, output: str) -> bool:
         """Check if output looks like pip list --outdated output."""
-        if output == "": # empty output indicates no updates found
+        if output == "":  # empty output indicates no updates found
             return True
         pip_header = ["Package", "Version", "Latest", "Type"]
         lines = output.split("\n")

--- a/changelog_checker/parsers/pip_parser.py
+++ b/changelog_checker/parsers/pip_parser.py
@@ -1,0 +1,44 @@
+"""
+Parser for pip package manager output.
+"""
+
+from changelog_checker.models import ChangeType, DependencyChange
+
+from .base import BaseParser
+
+
+class PipParser(BaseParser):
+    """Parser for (uv) pip list --outdated output."""
+
+    def get_package_manager_name(self) -> str:
+        return "pip"
+
+    def validate_output(self, output: str) -> bool:
+        """Check if output looks like pip list --outdated output."""
+        if output == "": # empty output indicates no updates found
+            return True
+        pip_header = ["Package", "Version", "Latest", "Type"]
+        lines = output.split("\n")
+        words = lines[0].split()
+        return words == pip_header
+
+    def parse(self, output: str) -> list[DependencyChange]:
+        """
+        Parse (uv) pip list --outdated output to extract dependency changes.
+
+        Expected format:
+        package     old_version     new_version     type
+        """
+        changes = []
+        lines = output.strip().split("\n")
+        for line in lines[2:]:
+            words = line.split()
+            package_name = words[0]
+            old_version = words[1]
+            new_version = words[2]
+            changes.append(
+                DependencyChange(
+                    name=package_name, change_type=ChangeType.UPDATED, old_version=old_version, new_version=new_version
+                )
+            )
+        return changes

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -103,7 +103,7 @@ class TestHTMLFormatter:
     @patch("changelog_checker.output.html_formatter.HAS_MARKDOWN_SUPPORT", True)
     def test_format_changelog_content_html_markdown(self):
         markdown_content = "# Header\n- List item"
-        with patch("changelog_checker.output.html_formatter.markdown") as mock_md:
+        with patch("changelog_checker.output.html_formatter.markdown", create=True) as mock_md:
             mock_md.markdown.return_value = "<h1>Header</h1><ul><li>List item</li></ul>"
             result = self.formatter._format_changelog_content_html(markdown_content)
             assert result == "<h1>Header</h1><ul><li>List item</li></ul>"
@@ -116,7 +116,11 @@ Header
 
 - List item
 """
-        with patch("changelog_checker.output.html_formatter.publish_parts") as mock_publish:
+        with (
+            patch("changelog_checker.output.html_formatter.docutils", create=True) as mock_doc,
+            patch("changelog_checker.output.html_formatter.publish_parts", create=True) as mock_publish,
+        ):
+            mock_doc.utils.Reporter.SEVERE_LEVEL = 4
             mock_publish.return_value = {"body": "<h1>Header</h1><ul><li>List item</li></ul>"}
             result = self.formatter._format_changelog_content_html(rst_content)
             assert result == "<h1>Header</h1><ul><li>List item</li></ul>"
@@ -125,7 +129,7 @@ Header
         markdown_content = "# Header\n- List item"
         with (
             patch("changelog_checker.output.html_formatter.HAS_MARKDOWN_SUPPORT", True),
-            patch("changelog_checker.output.html_formatter.markdown") as mock_md,
+            patch("changelog_checker.output.html_formatter.markdown", create=True) as mock_md,
         ):
             mock_md.markdown.side_effect = Exception("Rendering error")
             result = self.formatter._format_changelog_content_html(markdown_content)
@@ -193,7 +197,7 @@ Header
     def test_markdown_links_get_target_blank(self):
         """Test that markdown links get target='_blank' added."""
         markdown_content = "# Header\nCheck out [this link](https://example.com) for more info."
-        with patch("changelog_checker.output.html_formatter.markdown") as mock_md:
+        with patch("changelog_checker.output.html_formatter.markdown", create=True) as mock_md:
             mock_md.markdown.return_value = (
                 '<h1>Header</h1><p>Check out <a href="https://example.com">this link</a> for more info.</p>'
             )
@@ -209,7 +213,11 @@ Header
 
 Check out `this link <https://example.com>`__ for more info.
 """
-        with patch("changelog_checker.output.html_formatter.publish_parts") as mock_publish:
+        with (
+            patch("changelog_checker.output.html_formatter.docutils", create=True) as mock_doc,
+            patch("changelog_checker.output.html_formatter.publish_parts", create=True) as mock_publish,
+        ):
+            mock_doc.utils.Reporter.SEVERE_LEVEL = 4
             mock_publish.return_value = {
                 "body": (
                     '<p>Check out <a class="reference external" href="https://example.com">this link</a> for more info.</p>'

--- a/tests/test_pip_parser.py
+++ b/tests/test_pip_parser.py
@@ -1,0 +1,71 @@
+from changelog_checker.models import ChangeType
+from changelog_checker.parsers.pip_parser import PipParser
+
+
+class TestPipParser:
+    def setup_method(self):
+        self.parser = PipParser()
+
+    def test_get_package_manager_name(self):
+        assert self.parser.get_package_manager_name() == "pip"
+
+    def test_validate_output_valid(self):
+        valid_outputs = ["", "Package            Version         Latest          Type"]
+        for valid_output in valid_outputs:
+            assert self.parser.validate_output(valid_output), f"Should validate: {valid_output}"
+
+    def test_validate_output_invalid(self):
+        invalid_outputs = ["Random text without pip header"]
+        for invalid_output in invalid_outputs:
+            assert not self.parser.validate_output(invalid_output), f"Should not validate: {invalid_output}"
+
+    def test_parse_package_update(self):
+        output = """
+Package            Version         Latest          Type
+------------------ --------------- --------------- -----
+requests           2.32.4          2.32.5          wheel
+"""
+        changes = self.parser.parse(output)
+        assert len(changes) == 1
+        change = changes[0]
+        assert change.name == "requests"
+        assert change.change_type == ChangeType.UPDATED
+        assert change.old_version == "2.32.4"
+        assert change.new_version == "2.32.5"
+
+    def test_parse_multiple_changes(self):
+        output = """
+Package            Version         Latest          Type
+------------------ --------------- --------------- -----
+certifi            2025.7.9        2025.8.3        wheel
+charset-normalizer 3.4.2           3.4.3           wheel
+coverage           7.9.2           7.10.4          wheel
+distlib            0.3.9           0.4.0           wheel
+"""
+        changes = self.parser.parse(output)
+        assert len(changes) == 4
+        assert changes[0].name == "certifi"
+        assert changes[0].change_type == ChangeType.UPDATED
+        assert changes[0].old_version == "2025.7.9"
+        assert changes[0].new_version == "2025.8.3"
+        assert changes[1].name == "charset-normalizer"
+        assert changes[1].change_type == ChangeType.UPDATED
+        assert changes[1].old_version == "3.4.2"
+        assert changes[1].new_version == "3.4.3"
+        assert changes[2].name == "coverage"
+        assert changes[2].change_type == ChangeType.UPDATED
+        assert changes[2].old_version == "7.9.2"
+        assert changes[2].new_version == "7.10.4"
+        assert changes[3].name == "distlib"
+        assert changes[3].change_type == ChangeType.UPDATED
+        assert changes[3].old_version == "0.3.9"
+        assert changes[3].new_version == "0.4.0"
+
+    def test_parse_empty_output(self):
+        changes = self.parser.parse("")
+        assert changes == []
+
+    def test_parse_no_changes(self):
+        output = ""
+        changes = self.parser.parse(output)
+        assert changes == []


### PR DESCRIPTION
This adds a basic parser for the output of ```[uv] pip list --outdated```.

The motivation behind this is that in my projects, I've got all my dependencies pinned to exact version numbers, and I would like to check the changelogs wrt. the newest available version, in order to manually update my dependencies.

I found that ```[uv] pip list --outdated``` is the only way to get the required version information. With this parser, that output can be used with changelog-checker.

Please don't hesitate to let me know of any further changes that may be needed.